### PR TITLE
Parsowanie double

### DIFF
--- a/Zajecia5/WeatherApp/Model.Common/Model.Common.csproj
+++ b/Zajecia5/WeatherApp/Model.Common/Model.Common.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Model.Common</RootNamespace>
     <AssemblyName>Model.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Zajecia5/WeatherApp/Model.Common/Model.Common.csproj
+++ b/Zajecia5/WeatherApp/Model.Common/Model.Common.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Model.Common</RootNamespace>
     <AssemblyName>Model.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Zajecia5/WeatherApp/Model.WeatherLiveStation/Model.WeatherLiveStation.csproj
+++ b/Zajecia5/WeatherApp/Model.WeatherLiveStation/Model.WeatherLiveStation.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Model.WheatherLiveStation</RootNamespace>
     <AssemblyName>Model.WheatherLiveStation</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Zajecia5/WeatherApp/Model.WeatherLiveStation/Model.WeatherLiveStation.csproj
+++ b/Zajecia5/WeatherApp/Model.WeatherLiveStation/Model.WeatherLiveStation.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Model.WheatherLiveStation</RootNamespace>
     <AssemblyName>Model.WheatherLiveStation</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Zajecia5/WeatherApp/Model.WeatherLiveStation/WeatherLiveStation.cs
+++ b/Zajecia5/WeatherApp/Model.WeatherLiveStation/WeatherLiveStation.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Timers;
 using System.Xml;
 using Model.Common;
+using System.Globalization;
 
 namespace Model.WheatherLiveStation
 {
@@ -44,11 +45,11 @@ namespace Model.WheatherLiveStation
 
                 var nodes = xmlDocument.ChildNodes[1].ChildNodes;
                 var temperature =
-                    (int) double.Parse(nodes[1].Attributes.GetNamedItem("value").Value);
+                    (int) double.Parse(nodes[1].Attributes.GetNamedItem("value").Value, CultureInfo.InvariantCulture);
                 var pressure = 
-                    (int) double.Parse(nodes[3].Attributes.GetNamedItem("value").Value);
+                    (int) double.Parse(nodes[3].Attributes.GetNamedItem("value").Value, CultureInfo.InvariantCulture);
                 var wind =
-                    (int)double.Parse(nodes[4].FirstChild.Attributes.GetNamedItem("value").Value);
+                    (int)double.Parse(nodes[4].FirstChild.Attributes.GetNamedItem("value").Value, CultureInfo.InvariantCulture);
 
                 return new WeatherChangedArgs(temperature, pressure, wind);
             }

--- a/Zajecia5/WeatherApp/Model.WeatherMockStation/Model.WeatherMockStation.csproj
+++ b/Zajecia5/WeatherApp/Model.WeatherMockStation/Model.WeatherMockStation.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Model.WeatherMockStation</RootNamespace>
     <AssemblyName>Model.WeatherMockStation</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Zajecia5/WeatherApp/Model.WeatherMockStation/Model.WeatherMockStation.csproj
+++ b/Zajecia5/WeatherApp/Model.WeatherMockStation/Model.WeatherMockStation.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Model.WeatherMockStation</RootNamespace>
     <AssemblyName>Model.WeatherMockStation</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Zajecia5/WeatherApp/View/App.config
+++ b/Zajecia5/WeatherApp/View/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/>
     </startup>
 </configuration>

--- a/Zajecia5/WeatherApp/View/App.config
+++ b/Zajecia5/WeatherApp/View/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/Zajecia5/WeatherApp/View/Properties/Resources.Designer.cs
+++ b/Zajecia5/WeatherApp/View/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WeatherApp.Properties
-{
-
-
+namespace WeatherApp.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace WeatherApp.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("WheatherApp.Properties.Resources", typeof(Resources).Assembly);
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("WeatherApp.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/Zajecia5/WeatherApp/View/Properties/Settings.Designer.cs
+++ b/Zajecia5/WeatherApp/View/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WeatherApp.Properties
-{
-
-
+namespace WeatherApp.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/Zajecia5/WeatherApp/View/WeatherApp.csproj
+++ b/Zajecia5/WeatherApp/View/WeatherApp.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>WeatherApp</RootNamespace>
     <AssemblyName>WeatherApp</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/Zajecia5/WeatherApp/View/WeatherApp.csproj
+++ b/Zajecia5/WeatherApp/View/WeatherApp.csproj
@@ -8,11 +8,12 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>WeatherApp</RootNamespace>
     <AssemblyName>WeatherApp</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Zajecia5/WeatherApp/ViewModel.WeatherApp/ViewModel.WeatherApp.csproj
+++ b/Zajecia5/WeatherApp/ViewModel.WeatherApp/ViewModel.WeatherApp.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ViewModel.WeatherApp</RootNamespace>
     <AssemblyName>ViewModel.WeatherApp</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Zajecia5/WeatherApp/ViewModel.WeatherApp/ViewModel.WeatherApp.csproj
+++ b/Zajecia5/WeatherApp/ViewModel.WeatherApp/ViewModel.WeatherApp.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ViewModel.WeatherApp</RootNamespace>
     <AssemblyName>ViewModel.WeatherApp</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
na Windowsie na moim laptopie pojawił się błąd parsowanie double z dokumentu xml'a. Jakiś tam konflik z interrpetacją przecinka czy kropki, następujący commit naprawia problem.